### PR TITLE
Fixes Issue #5 - Switching Claro to the default theme

### DIFF
--- a/illinois_framework.info.yml
+++ b/illinois_framework.info.yml
@@ -75,5 +75,4 @@ install:
 themes:
   - bootstrap4
   - illinois_framework_theme
-  - seven
   - claro

--- a/illinois_framework.profile
+++ b/illinois_framework.profile
@@ -106,7 +106,7 @@ function illinois_framework_set_default_theme() {
   Drupal::configFactory()
     ->getEditable('system.theme')
     ->set('default', 'illinois_framework_theme')
-    ->set('admin', 'seven')
+    ->set('admin', 'claro')
     ->save(TRUE);
 
   // Use the admin theme for creating content.


### PR DESCRIPTION
Changed the admin theme to seven but the default theme should be set to claro.