### PR TITLE
Remove paragraphs perms

### DIFF
--- a/illinois_framework.info.yml
+++ b/illinois_framework.info.yml
@@ -51,7 +51,6 @@ install:
   - page_cache
   - paragraphs
   - paragraphs_library
-  - paragraphs_type_permissions
   - path
   - pathauto
   - pathologic

--- a/illinois_framework.info.yml
+++ b/illinois_framework.info.yml
@@ -58,6 +58,7 @@ install:
   - rdf
   - redirect
   - responsive_image
+  - scss_compiler
   - search
   - shortcut
   - tb_megamenu


### PR DESCRIPTION
Removes paragraphs_type_permissions from the default install of the ILFW. It caused issues with the anonymous user not being able to view published paragraphs since the default behavior is to not allow viewing paragraphs.

Also added scss_compiler to the default enabled list. It will compile our style.SCSS file in the theme on installation.