### PR TITLE
Update Drupal Core to version 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
         "web-illinois/illinois_framework_core": "1.x-dev",
         "web-illinois/illinois_framework_theme": "1.x-dev",
         "cweagans/composer-patches": "^1.7",
-        "drupal/bootstrap4": "2.1.5",
-        "drupal/core-recommended": "^8.9.0",
+        "drupal/core-recommended": "^9.2",
         "drush/drush": "^10.2"
     },
     "require-dev": {
@@ -71,9 +70,7 @@
         },
         "patches": {
             "drupal/core": {
-                "2869592 - Disabled update module shouldn't produce a status report warning": "https://www.drupal.org/files/issues/2020-02-07/2869592-remove-update-warning-34.patch",
-                "1356276 - Allow profiles to define a base/parent profile and load them in the correct order": "https://www.drupal.org/files/issues/2019-11-05/1356276-531-8.8.x-4.patch",
-                "2914389 - Allow profiles to exclude dependencies of their parent": "https://www.drupal.org/files/issues/2018-07-09/2914389-8-do-not-test.patch"
+                "2869592 - Disabled update module shouldn't produce a status report warning": "https://www.drupal.org/files/issues/2020-02-07/2869592-remove-update-warning-34.patch"
             }
         }
     },

--- a/illinois_framework.info.yml
+++ b/illinois_framework.info.yml
@@ -1,5 +1,5 @@
 name: Illinois Framework
-core_version_requirement: '^8.8'
+core_version_requirement: ^8 || ^9
 type: profile
 description: A Drupal distribution tailored for the University of Illinois.
 


### PR DESCRIPTION
Changes needed for Drupal 9 upgrade. Needs to be merged with updates to the theme and core repos.