### PR TITLE
Move core image styles to profile to prevent install error

### DIFF
--- a/config/install/image.style.large.yml
+++ b/config/install/image.style.large.yml
@@ -1,0 +1,26 @@
+uuid: 34772786-c6aa-4e4b-a62f-b7aaa329a616
+langcode: en
+status: true
+dependencies:
+  module:
+    - imagick
+_core:
+  default_config_hash: J2n0RpFzS0-bgSyxjs6rSdgxB1rb-bTAgqywNx_964M
+name: large
+label: 'Large (480×480)'
+effects:
+  ddd73aa7-4bd6-4c85-b600-bdf2b1628d1d:
+    uuid: ddd73aa7-4bd6-4c85-b600-bdf2b1628d1d
+    id: image_scale
+    weight: 0
+    data:
+      width: 480
+      height: 480
+      upscale: false
+  21c66d94-9f73-4f0f-8b72-e6a91ed3f1a2:
+    uuid: 21c66d94-9f73-4f0f-8b72-e6a91ed3f1a2
+    id: image_convert
+    weight: 2
+    data:
+      format: jpg
+      quality: '85'

--- a/config/install/image.style.media_library.yml
+++ b/config/install/image.style.media_library.yml
@@ -1,0 +1,29 @@
+uuid: 279ef609-eeca-4fae-8977-ce3d9799593f
+langcode: en
+status: true
+dependencies:
+  module:
+    - imagick
+  enforced:
+    module:
+      - media_library
+_core:
+  default_config_hash: 7qJqToD1OQLAyeswpmg7M0LRxQlw1URQkJDWUJCnmR8
+name: media_library
+label: 'Media Library thumbnail (220×220)'
+effects:
+  75b076a8-1234-4b42-85db-bf377c4d8d5f:
+    uuid: 75b076a8-1234-4b42-85db-bf377c4d8d5f
+    id: image_scale
+    weight: 0
+    data:
+      width: 220
+      height: 220
+      upscale: false
+  70afa829-3132-4eed-8a67-fc8ff36deacd:
+    uuid: 70afa829-3132-4eed-8a67-fc8ff36deacd
+    id: image_convert
+    weight: 2
+    data:
+      format: jpg
+      quality: '85'

--- a/config/install/image.style.medium.yml
+++ b/config/install/image.style.medium.yml
@@ -1,0 +1,26 @@
+uuid: 3de779ca-34d9-4373-b9f1-72ad5b55db20
+langcode: en
+status: true
+dependencies:
+  module:
+    - imagick
+_core:
+  default_config_hash: Y9NmnZHQq20ASSyTNA6JnwtWrJJiSajOehGDtmUFdM0
+name: medium
+label: 'Medium (220×220)'
+effects:
+  bddf0d06-42f9-4c75-a700-a33cafa25ea0:
+    uuid: bddf0d06-42f9-4c75-a700-a33cafa25ea0
+    id: image_scale
+    weight: 0
+    data:
+      width: 220
+      height: 220
+      upscale: false
+  2c2e8f3a-557a-4c3f-8867-0909a5d2d9c1:
+    uuid: 2c2e8f3a-557a-4c3f-8867-0909a5d2d9c1
+    id: image_convert
+    weight: 2
+    data:
+      format: jpg
+      quality: '85'

--- a/config/install/image.style.thumbnail.yml
+++ b/config/install/image.style.thumbnail.yml
@@ -1,0 +1,26 @@
+uuid: 91027c26-a596-48de-a85a-a52c2dc3c316
+langcode: en
+status: true
+dependencies:
+  module:
+    - imagick
+_core:
+  default_config_hash: cCiWdBHgLwj5omG35lsKc4LkW4MBdmcctkVop4ol5x0
+name: thumbnail
+label: 'Thumbnail (100×100)'
+effects:
+  1cfec298-8620-4749-b100-ccb6c4500779:
+    uuid: 1cfec298-8620-4749-b100-ccb6c4500779
+    id: image_scale
+    weight: 0
+    data:
+      width: 100
+      height: 100
+      upscale: false
+  d940b161-3a90-4989-886e-5f40b3136395:
+    uuid: d940b161-3a90-4989-886e-5f40b3136395
+    id: image_convert
+    weight: 2
+    data:
+      format: jpg
+      quality: '85'

--- a/config/install/image.style.video_embed_wysiwyg_preview.yml
+++ b/config/install/image.style.video_embed_wysiwyg_preview.yml
@@ -1,0 +1,29 @@
+uuid: 19a71251-4a4d-4e65-94af-572a02f473d4
+langcode: en
+status: true
+dependencies:
+  module:
+    - imagick
+  enforced:
+    module:
+      - video_embed_wysiwyg
+_core:
+  default_config_hash: eQ9aeNMJhpII0KPnOnS9JWMGgHLrMrmY3yDBuwswS4I
+name: video_embed_wysiwyg_preview
+label: 'Video Embed Wysiwyg: Thumbnail Preview'
+effects:
+  ba339f97-d07b-476d-9058-6c86c78329a1:
+    uuid: ba339f97-d07b-476d-9058-6c86c78329a1
+    id: image_scale
+    weight: 1
+    data:
+      width: null
+      height: 270
+      upscale: false
+  db74418b-7265-4c6a-be96-3d452d512fa8:
+    uuid: db74418b-7265-4c6a-be96-3d452d512fa8
+    id: image_convert
+    weight: 2
+    data:
+      format: jpg
+      quality: '85'


### PR DESCRIPTION
Fixes issue installing a new site. Installing a new site was throwing a configuration already exists error. Moved image style config from core module to profile.