### PR TITLE
Remove bootstrap4 theme requirement

### DIFF
--- a/illinois_framework.info.yml
+++ b/illinois_framework.info.yml
@@ -80,7 +80,6 @@ install:
   - workflows
   - illinois_framework_core
 themes:
-  - bootstrap4
   - illinois_framework_theme
   - claro
   - gin


### PR DESCRIPTION
Bootstrap4 is no longer the ILFW theme's parent theme.