### PR TITLE
Fix for issue #56 - remove scss_compiler and claro

### DIFF
--- a/illinois_framework.info.yml
+++ b/illinois_framework.info.yml
@@ -64,7 +64,6 @@ install:
   - pathologic
   - redirect
   - responsive_image
-  - scss_compiler
   - search
   - shortcut
   - taxonomy
@@ -79,5 +78,4 @@ install:
   - illinois_framework_core
 themes:
   - illinois_framework_theme
-  - claro
   - gin


### PR DESCRIPTION
Closes #56 - Remove scss_compiler and claro from illinois_framework.info.yml