### PR TITLE
Add a recipe that can be applied to unset search settings.

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -1,0 +1,9 @@
+name: Drupal Core Search Settings
+description: Sets good settings for core search.
+type: 'content_search'
+config:
+  actions:
+    search.page.help_search:
+      disable: []
+    search.page.user_search:
+      disable: []


### PR DESCRIPTION
Modifies search pages to disabled status, so that they are no longer creating tabs on search. Addresses #58 

Testing steps

1. Uninstall and reinstall the search module.
2. Review its search pages and see an active help, users, node search pages.
3. With https://github.com/web-illinois/las_ilfw_pantheonupstream/pull/30 resolved, continue
4. Run `lando drush recipe /modules/contrib/illinois_framework_profile` (if version is updated) otherwise point to where module is located, relative to web root.
5. Review the search pages and see that help and user search pages are disabled.