### PR TITLE
Feature/issue 1346 create release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,302 @@
+# .github/workflows/create-release.yml
+# This workflow is triggered manually to create a new release of the profile.
+# It updates the version in the .info.yml, pins the core/theme dependencies in
+# composer.json to the matching major.minor (~X.Y.0), tags the commit, and opens
+# a DRAFT GitHub Release with auto-generated notes so you can add custom notes
+# before publishing.
+
+name: Create New Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The new version number (MAJOR.MINOR.PATCH, e.g., 5.2.0)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run: build and print info.yml + composer.json, but do NOT commit, tag, or release.'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit, tag, and release.
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          # Full history + tags are needed to diff against the previous
+          # release when drafting release notes.
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Ensure tag does not already exist
+        run: |
+          # Fail fast (before the AI call and any commit) if the release tag
+          # already exists locally or on the remote. The workflow never uses
+          # --force, so a pre-existing tag would otherwise fail later with a
+          # raw git error; this gives a clear message and avoids wasted work.
+          VERSION="${{ github.event.inputs.version }}"
+          if git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
+            echo "::error::Tag ${VERSION} already exists. Choose a new version or delete the existing tag."
+            exit 1
+          fi
+
+      - name: Validate version and derive Composer constraint
+        run: |
+          # The profile pins its core/theme dependencies to the release's
+          # major.minor, so the version must be a plain MAJOR.MINOR.PATCH with
+          # no pre-release/build suffix. Reject anything else up front.
+          VERSION="${{ github.event.inputs.version }}"
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Version must be MAJOR.MINOR.PATCH with no suffix (e.g. 5.2.0). Got: '${VERSION}'"
+            exit 1
+          fi
+
+          # Derive the tilde constraint ~MAJOR.MINOR.0, which Composer expands to
+          # >=MAJOR.MINOR.0 <MAJOR.(MINOR+1).0 — major.minor stays in sync with
+          # the profile release while the patch level may differ.
+          MAJOR="${VERSION%%.*}"
+          REST="${VERSION#*.}"
+          MINOR="${REST%%.*}"
+          CONSTRAINT="~${MAJOR}.${MINOR}.0"
+
+          # Export for later steps (composer pin + dry-run summary).
+          echo "CONSTRAINT=${CONSTRAINT}" >> "$GITHUB_ENV"
+          echo "Derived Composer constraint for core/theme: ${CONSTRAINT}"
+
+      - name: Add packaging metadata to info.yml
+        run: |
+          # Mirrors the Drupal.org packaging script, which appends a
+          # version/project/datestamp block to each .info.yml at build time.
+          VERSION="${{ github.event.inputs.version }}"
+          PROJECT="illinois_framework"
+          INFO_FILE="illinois_framework.info.yml"
+          BUILD_DATE="$(date -u +%Y-%m-%d)"
+          DATESTAMP="$(date -u +%s)"
+
+          # Strip any existing packaging metadata so re-runs stay idempotent
+          # (removes the comment line plus the three generated keys).
+          sed -i \
+            -e '/^# Information added by .* packaging script on /d' \
+            -e '/^version: /d' \
+            -e '/^project: /d' \
+            -e '/^datestamp: /d' \
+            "$INFO_FILE"
+
+          # Drop any trailing blank lines left behind before appending.
+          awk 'NF{last=NR} {line[NR]=$0} END{for(i=1;i<=last;i++) print line[i]}' \
+            "$INFO_FILE" > "$INFO_FILE.tmp" && mv "$INFO_FILE.tmp" "$INFO_FILE"
+
+          # Append a fresh metadata block. Single quotes matter for Drupal's
+          # YAML parser (keeps version strings like '5.0' from becoming floats).
+          # Built with printf (not a heredoc) so the block stays indented inside
+          # this YAML step while still writing column-0 lines to the info file.
+          {
+            printf '\n'
+            printf '# Information added by web-illinois packaging script on %s\n' "$BUILD_DATE"
+            printf "version: '%s'\n" "$VERSION"
+            printf "project: '%s'\n" "$PROJECT"
+            printf 'datestamp: %s\n' "$DATESTAMP"
+          } >> "$INFO_FILE"
+
+          echo "----- Generated $INFO_FILE -----"
+          cat "$INFO_FILE"
+
+      - name: Pin core/theme constraints in composer.json
+        run: |
+          # Lock the profile's Illinois Framework dependencies to the release's
+          # major.minor so a released profile always installs a matching
+          # core/theme. CONSTRAINT (~X.Y.0) is exported by the validation step.
+          #
+          # A targeted sed edits ONLY the two require lines, preserving the
+          # file's existing formatting. The value pattern "[^"]*" matches any
+          # current constraint (e.g. 5.x-dev or a previous ~X.Y.0), so re-runs
+          # are idempotent.
+          sed -i -E \
+            's#("web-illinois/illinois_framework_(core|theme)"[[:space:]]*:[[:space:]]*)"[^"]*"#\1"'"${CONSTRAINT}"'"#g' \
+            composer.json
+
+          # Validate the result: composer.json must still be valid JSON and both
+          # dependencies must now equal the derived constraint. jq -e exits
+          # non-zero if the expression is false/null or the JSON is invalid.
+          if ! jq -e --arg c "${CONSTRAINT}" \
+              '.require["web-illinois/illinois_framework_core"] == $c and .require["web-illinois/illinois_framework_theme"] == $c' \
+              composer.json >/dev/null; then
+            echo "::error::Failed to pin core/theme to ${CONSTRAINT} in composer.json."
+            echo "----- composer.json require -----"
+            jq '.require' composer.json || cat composer.json
+            exit 1
+          fi
+
+          echo "----- Pinned core/theme to ${CONSTRAINT} -----"
+          jq '.require' composer.json
+
+      - name: Determine previous release tag
+        id: prevtag
+        run: |
+          # The release tag isn't created yet, so the newest existing tag is
+          # the previous release. Empty on the very first release.
+          PREV_TAG="$(git tag --sort=-creatordate | head -n1)"
+          echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
+          echo "Previous tag: ${PREV_TAG:-<none>}"
+
+      - name: Collect changes since last release
+        run: |
+          if [ -n "${{ steps.prevtag.outputs.prev_tag }}" ]; then
+            RANGE="${{ steps.prevtag.outputs.prev_tag }}..HEAD"
+          else
+            RANGE="HEAD"
+          fi
+          # Subjects + bodies give the AI enough to spot #issue / #PR references.
+          LOG="$(git log $RANGE --no-merges --pretty=format:'- %s%n%b' | head -c 12000)"
+          {
+            echo "COMMIT_LOG<<COMMIT_LOG_EOF"
+            echo "$LOG"
+            echo "COMMIT_LOG_EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Draft "Release Notes" section with AI (Azure OpenAI v1)
+        env:
+          # Secret: the Azure OpenAI / Foundry API key (Settings > Secrets and variables > Actions).
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          # Non-secret Actions variables (Settings > Secrets and variables > Actions > Variables):
+          #   AZURE_OPENAI_BASE_URL  the v1 API base, e.g.
+          #                          https://uiuc-las-ai-agent.openai.azure.com/openai/v1
+          #   AZURE_OPENAI_MODEL     the model deployment name, e.g. gpt-5.6-luna
+          AZURE_OPENAI_BASE_URL: ${{ vars.AZURE_OPENAI_BASE_URL }}
+          AZURE_OPENAI_MODEL: ${{ vars.AZURE_OPENAI_MODEL }}
+          # Passed via env (not inline ${{ }}) to avoid shell script injection.
+          VERSION: ${{ github.event.inputs.version }}
+          PREV_TAG: ${{ steps.prevtag.outputs.prev_tag }}
+          # COMMIT_LOG is exported by the previous step via $GITHUB_ENV.
+        run: |
+          set -euo pipefail
+
+          if [ -z "${AZURE_OPENAI_API_KEY:-}" ] || [ -z "${AZURE_OPENAI_BASE_URL:-}" ] || [ -z "${AZURE_OPENAI_MODEL:-}" ]; then
+            echo "::error::Missing Azure OpenAI config. Set the AZURE_OPENAI_API_KEY secret and the AZURE_OPENAI_BASE_URL / AZURE_OPENAI_MODEL variables."
+            exit 1
+          fi
+
+          # System prompt kept apostrophe-free so single-quoted lines stay simple.
+          SYSTEM_PROMPT="$(printf '%s\n' \
+            'You write release notes for the Illinois Framework Drupal distribution (install profile).' \
+            'Output ONLY Markdown for a single section and nothing else.' \
+            'Start with the level-2 heading exactly: ## Release Notes' \
+            'Then include a "### New Features" list and/or a "### Bug Fixes" list.' \
+            'Omit a subsection that would be empty.' \
+            'Each bullet is a concise, user-facing summary of one change.' \
+            'When a change references an issue or PR number like #123, append it as (#123) so GitHub auto-links it. Never invent numbers.' \
+            'Ignore administrative commits such as version bumps, merges, CI changes, dependency lockfiles, and formatting-only changes.' \
+            'Do not add a pull-request changelog section; it is appended automatically later.' \
+            'If there are no user-facing changes, output the heading ## Release Notes followed by: _No user-facing changes in this release._')"
+
+          USER_PROMPT="$(printf 'Version being released: %s\nPrevious release: %s\n\nCommit log since the previous release:\n%s\n' \
+            "$VERSION" "${PREV_TAG:-none}" "${COMMIT_LOG:-}")"
+
+          # Build the request body with jq so all content is safely JSON-escaped.
+          # v1 API: the model deployment name goes in the body, not the URL.
+          # GPT-5-series (reasoning) models require max_completion_tokens instead
+          # of max_tokens and only accept the default temperature, so temperature
+          # is omitted. The budget is generous because reasoning tokens count
+          # toward max_completion_tokens.
+          REQUEST="$(jq -n \
+            --arg model "$AZURE_OPENAI_MODEL" \
+            --arg sys "$SYSTEM_PROMPT" \
+            --arg usr "$USER_PROMPT" \
+            '{model: $model, messages: [{role: "system", content: $sys}, {role: "user", content: $usr}], max_completion_tokens: 2000}')"
+
+          # v1 GA API: POST to <base>/chat/completions, no api-version query param.
+          URL="${AZURE_OPENAI_BASE_URL%/}/chat/completions"
+
+          # --fail-with-body: on HTTP >=400, print the error body and fail the step.
+          set +e
+          RESP="$(curl -sS --fail-with-body -X POST "$URL" \
+            -H 'Content-Type: application/json' \
+            -H "api-key: ${AZURE_OPENAI_API_KEY}" \
+            -d "$REQUEST")"
+          CURL_EXIT=$?
+          set -e
+          if [ "$CURL_EXIT" -ne 0 ]; then
+            echo "::error::Azure OpenAI request failed (curl exit $CURL_EXIT)."
+            echo "$RESP"
+            exit 1
+          fi
+
+          NOTES="$(printf '%s' "$RESP" | jq -r '.choices[0].message.content // empty')"
+          if [ -z "$NOTES" ]; then
+            NOTES="$(printf '%s\n\n%s\n' '## Release Notes' '_No release notes were generated. Please edit before publishing._')"
+          fi
+
+          printf '%s\n' "$NOTES" > RELEASE_BODY.md
+          echo "----- RELEASE_BODY.md -----"
+          cat RELEASE_BODY.md
+
+      - name: Dry run summary
+        if: github.event.inputs.dry_run == 'true'
+        run: |
+          echo "::notice::Dry run enabled — no commit, tag, or release was created."
+          {
+            echo "### Dry run: generated info.yml"
+            echo '```yaml'
+            cat illinois_framework.info.yml
+            echo '```'
+            echo "### Dry run: composer.json require (core/theme pinned to ${CONSTRAINT})"
+            echo '```json'
+            jq '.require' composer.json
+            echo '```'
+            echo "### Dry run: AI-drafted release notes"
+            echo "_GitHub's \"What's Changed\" PR list is appended automatically at release time._"
+            echo ""
+            cat RELEASE_BODY.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit version update
+        if: github.event.inputs.dry_run != 'true'
+        id: commit
+        run: |
+          git add illinois_framework.info.yml composer.json
+          # Check if there are any changes to commit
+          if ! git diff --staged --quiet; then
+            git commit -m "Chore: Bump version to ${{ github.event.inputs.version }} (pin core/theme to ${CONSTRAINT})"
+            echo "changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "No version change detected."
+            echo "changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create and push tag
+        if: github.event.inputs.dry_run != 'true' && steps.commit.outputs.changes == 'true'
+        run: |
+          # Tag the local version-bump commit, then push ONLY the tag.
+          # The protected branch (e.g. 5.x) is never pushed to, so branch
+          # protection is satisfied. The metadata-bearing commit is reachable
+          # via the tag, which is what the Composer VCS install pulls from.
+          git tag "${{ github.event.inputs.version }}"
+          git push origin "refs/tags/${{ github.event.inputs.version }}"
+
+      - name: Create GitHub Release (draft)
+        if: github.event.inputs.dry_run != 'true' && steps.commit.outputs.changes == 'true'
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: "${{ github.event.inputs.version }}"
+          name: "Release ${{ github.event.inputs.version }}"
+          # The AI-drafted "## Release Notes" section becomes the top of the
+          # body; generate_release_notes appends GitHub's "## What's Changed"
+          # PR list below it. Created as a draft so you can review and edit the
+          # AI output before publishing.
+          body_path: RELEASE_BODY.md
+          generate_release_notes: true
+          draft: true
+          prerelease: false

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -74,6 +74,24 @@ jobs:
           echo "CONSTRAINT=${CONSTRAINT}" >> "$GITHUB_ENV"
           echo "Derived Composer constraint for core/theme: ${CONSTRAINT}"
 
+      - name: Verify matching core/theme releases exist
+        run: |
+          # Profile pins core/theme to ~MAJOR.MINOR.0, so a matching MAJOR.MINOR.*
+          # release must already exist in both repos or a `composer install` of
+          # this profile release would fail to resolve. ls-remote is read-only and
+          # needs no auth (both repos are public). CONSTRAINT is exported above.
+          MM="${CONSTRAINT#\~}"   # ~5.2.0 -> 5.2.0
+          MM="${MM%.*}"           # 5.2.0 -> 5.2
+          for repo in illinois_framework_core illinois_framework_theme; do
+            url="https://github.com/web-illinois/${repo}.git"
+            if git ls-remote --tags "$url" | grep -Eq "refs/tags/${MM}\.[0-9]+(\^\{\})?$"; then
+              echo "OK: ${repo} has a ${MM}.x release."
+            else
+              echo "::error::${repo} has no ${MM}.x release matching ${CONSTRAINT}. Release core and theme ${MM}.x first."
+              exit 1
+            fi
+          done
+
       - name: Add packaging metadata to info.yml
         run: |
           # Mirrors the Drupal.org packaging script, which appends a

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,181 @@
+# Releasing the Illinois Framework
+
+This guide explains how to cut a release of the Illinois Framework Drupal distribution,
+which spans three repositories. It is written for maintainers who trigger releases.
+
+- **Theme** — [`web-illinois/illinois_framework_theme`](https://github.com/web-illinois/illinois_framework_theme)
+- **Core module** — [`web-illinois/illinois_framework_core`](https://github.com/web-illinois/illinois_framework_core)
+- **Profile / distribution** — [`web-illinois/illinois_framework_profile`](https://github.com/web-illinois/illinois_framework_profile)
+
+Each repository ships a manual **"Create New Release"** GitHub Actions workflow
+(`.github/workflows/create-release.yml`) that does the heavy lifting: it stamps the
+version into the `.info.yml`, drafts AI-generated release notes, commits, tags, and opens
+a **draft** GitHub Release for you to review and publish.
+
+---
+
+## How the repos fit together
+
+```
+illinois_framework_profile  (distribution / install profile)
+├── requires web-illinois/illinois_framework_core   (composer.json)
+└── requires web-illinois/illinois_framework_theme  (composer.json)
+```
+
+The profile pins its `core` and `theme` dependencies to the **major.minor** of the
+release. Releasing profile `5.2.0` rewrites those two `composer.json` constraints to
+`~5.2.0` (i.e. `>=5.2.0 <5.3.0`): the major.minor stays in sync while the patch level may
+differ between the profile and the modules.
+
+### ⭐ Golden rule: release order
+
+> **Release the core and theme first (either order), then release the profile.**
+
+The profile release refuses to run unless a matching `MAJOR.MINOR.*` release already
+exists in **both** the core and theme repositories. This prevents publishing a profile
+release that cannot `composer install`.
+
+---
+
+## What every "Create New Release" run does
+
+All three repositories share the same base workflow. When you run it, it:
+
+1. Verifies the target tag does **not** already exist.
+2. Stamps a packaging block into the `.info.yml`
+   (`version` / `project` / `datestamp`), mirroring Drupal.org's packaging script.
+3. Drafts a `## Release Notes` section with AI from the commit log since the last tag
+   (see [Setup](#setup-secrets--variables)).
+4. Commits the version bump, creates the tag, and **pushes only the tag** — the protected
+   branch (e.g. `5.x`) is never pushed to, so branch protection is preserved.
+5. Opens a **draft** GitHub Release with the AI notes plus GitHub's auto-generated
+   "What's Changed" list. You review, edit, and publish it manually.
+
+The **profile** workflow additionally: validates the version is strict
+`MAJOR.MINOR.PATCH`, verifies matching core/theme releases exist, and pins the
+`core`/`theme` constraints in `composer.json` to `~MAJOR.MINOR.0`.
+
+### Common trigger steps
+
+For any repo:
+
+1. Open the repository on GitHub → **Actions** tab.
+2. Select **"Create New Release"** in the left sidebar.
+3. Click **Run workflow**.
+4. Leave the branch set to the default (`5.x`).
+5. Enter the **version** as `MAJOR.MINOR.PATCH` (e.g. `5.2.0`) — no `v` prefix, no suffix.
+6. (Optional) Set **dry_run** to `true` to preview the generated `.info.yml`
+   (and, for the profile, the pinned `composer.json`) in the run summary **without**
+   committing, tagging, or releasing.
+7. Click **Run workflow** and wait for it to finish.
+8. Go to **Releases**, open the new **draft**, review/edit the notes, and **Publish**.
+
+---
+
+## Step-by-step
+
+### 1. Release the Theme — `illinois_framework_theme`
+
+1. Decide the version (e.g. `5.2.0`).
+2. In the theme repo: **Actions → "Create New Release" → Run workflow**, branch `5.x`,
+   version `5.2.0`. Use **dry_run** first if you want to preview.
+3. Run it. The workflow stamps `illinois_framework_theme.info.yml`, tags `5.2.0`, and
+   opens a draft release.
+4. Open the draft under **Releases**, review the notes, and **Publish**.
+
+### 2. Release the Core module — `illinois_framework_core`
+
+1. Use the **same** version you released for the theme (e.g. `5.2.0`) so the major.minor
+   line up.
+2. In the core repo: **Actions → "Create New Release" → Run workflow**, branch `5.x`,
+   version `5.2.0`.
+3. Run it. The workflow stamps `illinois_framework_core.info.yml`, tags `5.2.0`, and opens
+   a draft release.
+4. Open the draft, review, and **Publish**.
+
+> The theme and core can be released in either order — both must be done **before** the
+> profile.
+
+### 3. Release the Profile — `illinois_framework_profile`
+
+Only after core **and** theme have matching `MAJOR.MINOR.*` releases published.
+
+1. In the profile repo: **Actions → "Create New Release" → Run workflow**, branch `5.x`,
+   version `5.2.0`.
+2. Before doing anything destructive, the workflow will:
+   - Validate the version is strict `MAJOR.MINOR.PATCH`.
+   - Derive the constraint `~5.2.0`.
+   - **Verify** that a `5.2.*` release tag exists in **both** core and theme. If either is
+     missing, the run **fails** with a clear message — go back and release the missing one.
+3. It then pins `web-illinois/illinois_framework_core` and
+   `web-illinois/illinois_framework_theme` in `composer.json` to `~5.2.0`, stamps
+   `illinois_framework.info.yml`, tags `5.2.0`, and opens a draft release.
+   (The pinned `composer.json` lives only in the tagged commit; the `5.x` branch keeps
+   `5.x-dev`.)
+4. Open the draft, review, and **Publish**.
+
+> **Tip:** run the profile workflow with **dry_run = true** first. The run summary shows
+> the generated `.info.yml` and the pinned `composer.json` `require` block so you can
+> confirm the constraints before the real run.
+
+---
+
+## Worked example: releasing 5.2.0 across the distribution
+
+1. **Theme** → Create New Release → `5.2.0` → publish the draft.
+2. **Core** → Create New Release → `5.2.0` → publish the draft.
+3. **Profile** → Create New Release → `5.2.0`.
+   - Passes the existence check (theme `5.2.0` and core `5.2.0` now exist).
+   - Pins `core` and `theme` to `~5.2.0` in `composer.json`.
+   - Publish the draft.
+
+Patch releases can diverge afterward: e.g. core may later ship `5.2.3` while the profile
+stays at `5.2.0` — the `~5.2.0` constraint still allows it.
+
+---
+
+## Setup: Secrets & Variables
+
+The **"Create New Release"** workflow needs the following configured in **each** of the
+three repositories (identical values). Set them under
+**Settings → Secrets and variables → Actions**.
+
+### Secrets (Settings → Secrets and variables → Actions → *Secrets* tab)
+
+| Name | Purpose |
+| --- | --- |
+| `AZURE_OPENAI_API_KEY` | API key for the Azure OpenAI / Foundry deployment used to draft the release notes. |
+| `GITHUB_TOKEN` | **Automatic** — provided by GitHub Actions; you do not create it. The workflow declares `permissions: contents: write` so this token can commit, tag, and create the release. |
+
+### Variables (Settings → Secrets and variables → Actions → *Variables* tab)
+
+| Name | Purpose | Example |
+| --- | --- | --- |
+| `AZURE_OPENAI_BASE_URL` | The Azure OpenAI **v1** API base URL. | `https://uiuc-las-ai-agent.openai.azure.com/openai/v1` |
+| `AZURE_OPENAI_MODEL` | The model **deployment** name. | `gpt-5.6-luna` |
+
+> All three repos (`theme`, `core`, `profile`) use the same three names. If the Azure
+> OpenAI secret/variables are missing, the release-notes step fails fast with a clear
+> error before anything is committed.
+
+---
+
+## Notes & troubleshooting
+
+- **"Tag `X.Y.Z` already exists"** — the version was already released. Pick a new version,
+  or delete the existing tag if it was created in error.
+- **Profile: "`illinois_framework_core`/`illinois_framework_theme` has no `X.Y.*`
+  release"** — you skipped the golden rule. Release the missing core/theme version first,
+  then re-run the profile workflow.
+- **"Missing Azure OpenAI config"** — set the `AZURE_OPENAI_API_KEY` secret and the
+  `AZURE_OPENAI_BASE_URL` / `AZURE_OPENAI_MODEL` variables in that repo (see
+  [Setup](#setup-secrets--variables)).
+- **Preview without side effects** — run with **dry_run = true**. Nothing is committed,
+  tagged, or released; the generated files are printed in the run summary.
+- **Nothing is pushed to the protected branch** — the workflow pushes only the tag. The
+  version bump (and, for the profile, the `composer.json` pin) exists on the tagged commit,
+  which is what Composer installs. The `5.x` branch keeps `5.x-dev`.
+- **Drafts are not auto-published** — every release is created as a **draft** on purpose.
+  Review and edit the AI-drafted notes, then publish manually.
+- **Version format** — always `MAJOR.MINOR.PATCH`, no `v` prefix and no pre-release/build
+  suffix (the profile enforces this strictly).

--- a/illinois_framework.info.yml
+++ b/illinois_framework.info.yml
@@ -2,6 +2,7 @@ name: Illinois Framework
 core_version_requirement: ^9 || ^10
 type: profile
 description: A Drupal distribution tailored for the University of Illinois.
+version: '5.x-dev'
 
 distribution:
   name: Illinois Framework


### PR DESCRIPTION
## 📝 Description

Adds an automated release workflow to the profile repo as part of the distribution-wide release automation (theme #1345 done; core and profile via **web-illinois/illinois_framework_theme#1346**).

This branch:

- **Adds `.github/workflows/create-release.yml`** — a manual **"Create New Release"** workflow (mirrors the theme/core workflow) that stamps the version into `illinois_framework.info.yml`, drafts AI release notes, commits, tags, pushes **only the tag** (preserving branch protection), and opens a **draft** GitHub Release.
- **Pins core/theme in `composer.json` on release** — because the profile is the distribution, the workflow rewrites `web-illinois/illinois_framework_core` and `..._theme` to `~MAJOR.MINOR.0` derived from the release version (e.g. releasing `5.2.0` → `~5.2.0`). Major.minor stays in sync with the release; the patch level may differ. The dev branch keeps `5.x-dev` — pinning lands only in the tagged commit.
- **Verifies matching core/theme releases exist** — before doing anything destructive, the workflow confirms a stable `MAJOR.MINOR.*` tag exists in **both** core and theme (read-only `git ls-remote`, no secrets), failing fast otherwise so a profile release can always `composer install`.
- **Sets `version: '5.x-dev'`** in `illinois_framework.info.yml` so the dev branch reports the dev version until a release tag replaces it.
- **Adds `RELEASING.md`** — step-by-step release instructions for all three repos, the required release order (core & theme before profile), a worked `5.2.0` example, the required secrets/variables, and troubleshooting.

Related issue: web-illinois/illinois_framework_theme#1346

### ⚙️ Setup required before first release
Configure in this repo under **Settings → Secrets and variables → Actions** (see `RELEASING.md`):
- Secret: `AZURE_OPENAI_API_KEY`
- Variables: `AZURE_OPENAI_BASE_URL`, `AZURE_OPENAI_MODEL`

